### PR TITLE
Correct use of btoa for non-ASCII characters

### DIFF
--- a/voter.js
+++ b/voter.js
@@ -901,7 +901,7 @@ function saveState(name, noActivate) {
     state.lastModified = new Date()
     //state.currentStep = currentStep
     state.name = name
-    let stateId = btoa(name + state.lastModified.toString()).substring(0, 64)
+    let stateId = btoa(name + state.lastModified.toISOString()).substring(0, 64)
     localStorage.setItem("state:" + stateId, JSON.stringify(state))
     // add name to savestate set
     let states = JSON.parse(localStorageDefault("states", "[]"))

--- a/voter.js
+++ b/voter.js
@@ -895,13 +895,31 @@ let state = {
  */
 }
 
+// convert a Unicode string to a string in which
+// each 16-bit unit occupies only one byte
+// licensed under CC0 from:
+// https://developer.mozilla.org/en-US/docs/Web/API/btoa#unicode_strings
+function toBinary(string) {
+    const codeUnits = new Uint16Array(string.length);
+    for (let i = 0; i < codeUnits.length; i++) {
+        codeUnits[i] = string.charCodeAt(i);
+    }
+    const charCodes = new Uint8Array(codeUnits.buffer);
+    let result = '';
+    for (let i = 0; i < charCodes.byteLength; i++) {
+        result += String.fromCharCode(charCodes[i]);
+    }
+    return result;
+}
+
 function saveState(name, noActivate) {
     // save the state
     state.currentStep = navStack.pop()
     state.lastModified = new Date()
     //state.currentStep = currentStep
     state.name = name
-    let stateId = btoa(name + state.lastModified.toISOString()).substring(0, 64)
+    let byteString = toBinary(name + state.lastModified.toISOString())
+    let stateId = btoa(byteString).substring(0, 64)
     localStorage.setItem("state:" + stateId, JSON.stringify(state))
     // add name to savestate set
     let states = JSON.parse(localStorageDefault("states", "[]"))


### PR DESCRIPTION
*Note: I kept my original description of the bug as much as possible, but this issue affects any browser language which is not English, not just French.*

When using Voter on a device with French locale, it is impossible to create your own saves. The console hinted at the reason: `Uncaught DOMException: String contains an invalid character @ voter.js:904`. After some tests, I have determined that the function btoa() complains about the `’ U+2019 Right Single Quotation Mark` character in the string obtained from the Date object (*edit: in fact, it's any non-ASCII character*):
```
testWed Jul 27 2022 11:27:26 GMT+0200 (heure d’été d’Europe centrale) @ debugger eval code:2:9
Uncaught DOMException: String contains an invalid character @ debugger eval code:3:5

testWed Jul 27 2022 11:27:26 GMT+0200 (heure d’ @ debugger eval code:3:9
Uncaught DOMException: String contains an invalid character @ debugger eval code:4:5

testWed Jul 27 2022 11:27:26 GMT+0200 (heure d @ debugger eval code:3:9
-> "dGVzdFdlZCBKdWwgMjcgMjAyMiAxMToyNzoyNiBHTVQrMDIwMCAoaGV1cmUgZA=="
```

This can be seen in the [MDN article on btoa()](https://developer.mozilla.org/en-US/docs/Web/API/btoa#unicode_strings). As the `’ U+2019 Right Single Quotation Mark` cannot be encoded in a single character, btoa() trips on it.

This should be solved by UTF-8 encoding the input as suggested in the article, as the user can give arbitrary names to saves. So that's what I did in the second commit. The licence should be fine, as all MDN code examples from 2010 onwards are CC0 licensed. And the btoa() page did not exist before 2017ish.

I believe this should be merged as this is a functionality fix. As specified, the save feature does not work if .toDateSting() gives non-ASCII characters, which is a noticeable functionality decrease.

--
Just in case that's required, as you don't seem to have a `CONTRIBUTING` file: "By submitting this merge request, I agree for my contribution to be licensed under MIT. To the extent permitted under applicable law, I agree to transfer all of my copyright and related rights associated with this contribution to George Brooke "figgyc", the author of the `voter2` tool."

--
*The original description explained the first commit and the use of toISOString:*

I just realised that the proper fix is required. :facepalm:

But this patch (*note: I mean the first of the two commits*) is only a hotfix, allowing for saves on non-English browsers if an ASCII name is provided.
The ISO date is always formatted as the UTC time for the corresponding Date object, in "yyyy-mm-ddThh:mm:ssZ" format and as such, has no non-ASCII characters. Also, I think that for this application where you want to get a unique key for the state by base64 "hashing" of name and timestamp, using the UTC time is better anyway.

I will try to make a better fix this evening. (*note: which I did, see the second commit*).